### PR TITLE
changed comment order - added email address

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -6,7 +6,7 @@
         Comments
       </h2>
       {% assign comments = site.data.comments[page.slug] | where_exp: 'comment', 'comment.replying_to == ""' %}
-      {% assign comments_by_date = comments | sort: 'date' | reverse %}
+      {% assign comments_by_date = comments | sort: 'date' %}
       {% for comment in comments_by_date %}
         {% assign       index = forloop.length | plus: 1 | minus: forloop.index %}
         {% assign replying_to = comment.replying_to | to_integer                %}

--- a/staticman.yml
+++ b/staticman.yml
@@ -35,6 +35,8 @@ comments:
     # Mailgun domain
     domain: "SgKlxFqzl3JdLsW8vhFBW4BCctefcenKdudh+4lWZyPc1g+gKHSUcoivPB/UraLj7a71SldhmWZkaF4JwKSb5uD835/D6s0np5aoP013t9RZBFf3zpjRypH0Kl5gxJCK+RvqMXwrDoIsH7qj00dM0StUQwkIu9LdAC4bhP6dPA8=" # !
 
+    fromAddress: tad@mg.tadmccorkle.com
+
   transforms:
     email: md5
 


### PR DESCRIPTION
- comments now display from oldest to newest - that is, the first comment will appear first, with more recent comments coming below it.
- added mailing address for mailgun notifications in case that was one of the reasons for notifications not being sent.